### PR TITLE
Relative import fix

### DIFF
--- a/scanner/scanner.odin
+++ b/scanner/scanner.odin
@@ -540,7 +540,9 @@ foreign wl_lib {
       if wayland_dir == "" {
          fmt.sbprintln(&sb, `import wl ".."`) // default
       } else {
-         output_dir := filepath.abs(output_path, context.temp_allocator) or_else output_path
+	 output_dir: string
+         output_dir_abs := filepath.abs(output_path, context.temp_allocator) or_else output_path
+	 output_dir, _ := os.split_path(output_dir_abs) 
          wayland_abs := filepath.abs(wayland_dir, context.temp_allocator) or_else wayland_dir
          rel_import := filepath.rel(output_dir, wayland_abs) or_else ".."
          fmt.sbprintfln(&sb, `import wl "%s"`, rel_import)

--- a/scanner/scanner.odin
+++ b/scanner/scanner.odin
@@ -540,9 +540,9 @@ foreign wl_lib {
       if wayland_dir == "" {
          fmt.sbprintln(&sb, `import wl ".."`) // default
       } else {
-	 output_dir: string
+         output_dir: string
          output_dir_abs := filepath.abs(output_path, context.temp_allocator) or_else output_path
-	 output_dir, _ := os.split_path(output_dir_abs) 
+         output_dir, _ := os.split_path(output_dir_abs) 
          wayland_abs := filepath.abs(wayland_dir, context.temp_allocator) or_else wayland_dir
          rel_import := filepath.rel(output_dir, wayland_abs) or_else ".."
          fmt.sbprintfln(&sb, `import wl "%s"`, rel_import)


### PR DESCRIPTION
The output file argument was being treated as both a directory and a file. This commit gets the directory of the output file and uses that to construct the relative path instead.