### PR TITLE
fix variable redeclaration so scanner compiles

### DIFF
--- a/scanner/scanner.odin
+++ b/scanner/scanner.odin
@@ -542,7 +542,7 @@ foreign wl_lib {
       } else {
          output_dir: string
          output_dir_abs := filepath.abs(output_path, context.temp_allocator) or_else output_path
-         output_dir, _ := os.split_path(output_dir_abs) 
+         output_dir, _ = os.split_path(output_dir_abs) 
          wayland_abs := filepath.abs(wayland_dir, context.temp_allocator) or_else wayland_dir
          rel_import := filepath.rel(output_dir, wayland_abs) or_else ".."
          fmt.sbprintfln(&sb, `import wl "%s"`, rel_import)


### PR DESCRIPTION
## Message
Just now started thinking to try my hand at learning/building some Wayland stuff and I wanted to use Odin, so I searched around and found this repo. It seems really cool, so glad y'all took the time to create it! It didn't compile for me immediately, but the fix was super easy, so I figured I'd send it to y'all. Thanks again for creating this!

## Description
With the current main branch, the scanner (`scanner/scanner.odin`) does not compile, with error "redeclaration in current scope" on line 545. The problem is simply that the variable `output_dir` was declared two lines before on line 543, so the `:=` operator combo isn't correct. This PR simply changes it to assignment (`=`).