### PR TITLE
Fix scanner's output directory to resolve before computing relative import path.

### DIFF
--- a/scanner/scanner.odin
+++ b/scanner/scanner.odin
@@ -540,11 +540,10 @@ foreign wl_lib {
       if wayland_dir == "" {
          fmt.sbprintln(&sb, `import wl ".."`) // default
       } else {
-         output_dir: string
-         output_dir_abs := filepath.abs(output_path, context.temp_allocator) or_else output_path
-         output_dir, _ = os.split_path(output_dir_abs) 
+         output_dir := filepath.dir(output_path, context.temp_allocator)
+         output_dir_abs := filepath.abs(output_dir, context.temp_allocator) or_else output_dir
          wayland_abs := filepath.abs(wayland_dir, context.temp_allocator) or_else wayland_dir
-         rel_import := filepath.rel(output_dir, wayland_abs) or_else ".."
+         rel_import := filepath.rel(output_dir_abs, wayland_abs) or_else ".."
          fmt.sbprintfln(&sb, `import wl "%s"`, rel_import)
       }
 


### PR DESCRIPTION
Extract the directory from output_path using `filepath.dir` (pure string manipulation, no disk access), then resolve that to an absolute path. The directory typically exists even if the output file doesn't.

For example, my file structure is:
```
proj-root/
├── wayland/
│   ├── odin-wayland/ 
│   └── ext-data-control/
│       └── ext_data_control.odin

```

When running
```
./wayland-scanner wayland/ext-data-control/ext-data-control-v1.xml wayland/ext-data-control/ext_data_control.odin ext_data_control false false
wayland/odin-wayland
```
I would get:

`import wl ".."` which resolves to `wayland/`

After the fix, I get:

`import wl "../odin-wayland"` which correctly resolves to `wayland/odin-wayland/`

This bug was invisible in the project's own usage because the bundled protocols output one directory below `odin-wayland` (e.g., `wp/viewporter.odin`), where `..` happens to be the correct import path. External consumers with different directory structures get the wrong import.